### PR TITLE
Fix failing tests

### DIFF
--- a/lib/tux/commands.rb
+++ b/lib/tux/commands.rb
@@ -5,7 +5,7 @@ module Tux
     def routes
       Tux.app_class.routes.inject([]) {|arr, (k,v)|
         arr += v.map {|regex,params,*|
-          path = params.empty? ? regex.inspect :
+          path = params.empty? ? regex.to_s :
             params.inject(regex.inspect) {|s,e| s.sub(/\([^()]+\)/, ":#{e}") }
           [k, (str = path[%r{/\^(.*)\$/}, 1]) ? str.tr('\\', '') : path]
         }


### PR DESCRIPTION
Running `rake` gives a few errors.

<details><summary>Before</summary>

```
$> rake
bacon -q -Ilib -I. test/*_test.rb
......FF
Finished in 0.112187068 seconds.
Bacon::Error: "#<Mustermann::Sinatra:\"/\">".==("/") failed
        tux/test/commands_test.rb:39:in `block (3 levels) in <top (required)>': #routes - retrieves string path
        tux/test/commands_test.rb:38:in `block (2 levels) in <top (required)>'
        ruby/2.3.8/lib/ruby/gems/2.3.0/gems/bacon-bits-0.1.0/lib/bacon/bits.rb:20:in `describe'
        tux/test/commands_test.rb:37:in `block in <top (required)>'
        tux/test/commands_test.rb:3:in `<top (required)>'

Bacon::Error: "#<Mustermann::Sinatra:\"/:id/:format\">".==("/:id/:format") failed
        tux/test/commands_test.rb:43:in `block (3 levels) in <top (required)>': #routes - retrieves path with params
        tux/test/commands_test.rb:42:in `block (2 levels) in <top (required)>'
        ruby/2.3.8/lib/ruby/gems/2.3.0/gems/bacon-bits-0.1.0/lib/bacon/bits.rb:20:in `describe'
        tux/test/commands_test.rb:37:in `block in <top (required)>'
        tux/test/commands_test.rb:3:in `<top (required)>'

8 tests, 9 assertions, 2 failures, 0 errors
rake aborted!
Command failed with status (1): [bacon -q -Ilib -I. test/*_test.rb...]
tux/Rakefile:32:in `block in <top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

</details>

<details><summary>After</summary>

```
$> rake
bacon -q -Ilib -I. test/*_test.rb
........
Finished in 0.111346606 seconds.

8 tests, 9 assertions, 0 failures, 0 errors
```

</details>

I tested it with ruby `2.3.8`, `2.7.8` and `3.0.5` , all has the same outputs